### PR TITLE
WildlifeCompliance: merge fixes

### DIFF
--- a/wildlifecompliance/components/applications/models.py
+++ b/wildlifecompliance/components/applications/models.py
@@ -1330,7 +1330,8 @@ class Application(RevisionedMixin):
                     activity_status=ApplicationSelectedActivity.ACTIVITY_STATUS_CURRENT
                 ).first():
                     raise WildlifeLicence.DoesNotExist
-
+            else:
+                raise WildlifeLicence.DoesNotExist
             return existing_licence, False
         except WildlifeLicence.DoesNotExist:
             return WildlifeLicence.objects.create(
@@ -1371,6 +1372,11 @@ class Application(RevisionedMixin):
                             original_issue_date = latest_activity.original_issue_date
                             start_date = latest_activity.start_date
                             expiry_date = latest_activity.expiry_date
+
+                            # Set activity_status for latest_activity to REPLACED
+                            latest_activity.activity_status = ApplicationSelectedActivity.ACTIVITY_STATUS_REPLACED
+                            latest_activity.save()
+
                         selected_activity.issue_date = timezone.now()
                         selected_activity.updated_by = request.user
                         selected_activity.decision_action = ApplicationSelectedActivity.DECISION_ACTION_ISSUED
@@ -1561,7 +1567,6 @@ class Application(RevisionedMixin):
         proxy_details = request.user.get_wildlifecompliance_proxy_details(request)
         proxy_id = proxy_details.get('proxy_id')
         organisation_id = proxy_details.get('organisation_id')
-
         return Application.objects.filter(
             Q(org_applicant_id=organisation_id) if organisation_id
             else (
@@ -1929,6 +1934,22 @@ class ApplicationSelectedActivity(models.Model):
     @property
     def purposes(self):
         from wildlifecompliance.components.licences.models import LicencePurpose
+        return LicencePurpose.objects.filter(
+            application__id=self.application_id,
+            licence_activity_id=self.licence_activity_id
+        ).distinct()
+
+    @property
+    def current_purposes(self):
+        '''
+        need to clarify why ASA.purposes uses activity chain, should this be renamed to "current_purposes"?
+        should there be a separate function that just returns the purposes for the individual ASA?
+        after checking usage of .purposes, it seems maybe this was replaced by the creation of "current_activities"
+        may not need this if current_activities is correct, then purposes for an ASA should always
+        just show its own purposes, not full chain list
+        '''
+
+        from wildlifecompliance.components.licences.models import LicencePurpose
         activity_chain = self.application.get_activity_chain(
             licence_activity_id=self.licence_activity_id,
             activity_status=ApplicationSelectedActivity.ACTIVITY_STATUS_CURRENT
@@ -1937,7 +1958,7 @@ class ApplicationSelectedActivity(models.Model):
         return LicencePurpose.objects.filter(
             application__id__in=application_ids,
             licence_activity_id=self.licence_activity_id
-        )
+        ).distinct()
 
     @property
     def can_renew(self):

--- a/wildlifecompliance/components/licences/api.py
+++ b/wildlifecompliance/components/licences/api.py
@@ -257,7 +257,7 @@ class LicenceViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
-    @detail_route(methods=['GET', ])
+    @detail_route(methods=['POST', ])
     def cancel_activity(self, request, pk=None, *args, **kwargs):
         try:
             activity_id = request.GET.get('activity_id', None)

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/common/licences_dashboard.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/common/licences_dashboard.vue
@@ -339,6 +339,32 @@ export default {
                 var licence_id = $(this).attr('lic-id');
                 console.log('cancel-activity: activity : ' + activity_id);
                 console.log('cancel-activity: licence : ' + licence_id);
+                swal({
+                    title: "Cancel Activity",
+                    text: "Are you sure you want to cancel this activity?",
+                    type: "question",
+                    showCancelButton: true,
+                    confirmButtonText: 'Accept'
+                }).then((result) => {
+                    if (result.value) {
+                       vm.$http.post(helpers.add_endpoint_join(api_endpoints.licences,licence_id+'/cancel_activity/?activity_id=' + activity_id)).then(res=>{
+                            swal({
+                                title: "Cancel Activity",
+                                text: "The activity has been cancelled",
+                                type: "information"
+                            })
+                            vm.$refs.licence_datatable.vmDataTable.ajax.reload();
+                        },err=>{
+                            swal(
+                                'Submit Error',
+                                helpers.apiVueResourceError(err),
+                                'error'
+                            )
+                        });
+                    }
+                },(error) => {
+                });
+
             });
             // Suspend activity listener
             vm.$refs.licence_datatable.vmDataTable.on('click', 'a[suspend-activity]', function(e) {


### PR DESCRIPTION
1. In get_parent_licence, there was still a case where None would be returned because there was an else statement missing for the "if existing_licence" where if it was None
2. When processing an amend activity application, previous ASAs weren't being marked as replaced
3. After doing amend activity, the purposes list was growing, showing duplicates due to the activity chain displaying the ASA's purposes from any application in the chain which had a current ASA; ASA.purposes property function now lists only the purposes linked with this ASA (not full chain)
4. Changed the list function for the UserAvailableWildlifeLicencePurposesViewSet to use the current_activities queryset defined earlier in the function and used a loop to extend the results of those into active_purpose_ids